### PR TITLE
修改session的配置，可以支持覆盖session类

### DIFF
--- a/src/web/RedisSession.php
+++ b/src/web/RedisSession.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * User: lbmzorx
+ * Date: 2018/4/2
+ * Time: 17:09
+ */
+namespace feehi\web;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use \yii\redis\Connection;
+
+/**
+ * Class RedisSession
+ *
+ * you can config conponents to use RedisSession,make sure you have installed redis and composer Yii-Redis.you can learn yii-redis
+ * from https://github.com/yiisoft/yii2-redis
+ * config
+ *  'components'=>[
+ *  ...
+ *      'session'=>[
+ *          'class'=>'feehi\web\RedisSession',
+ *          'timeout'=>'1400',
+ *          'redis'=>[
+ *                 'hostname' => '127.0.0.1',
+ *                 'port' => 6379,
+ *          ],
+ *      ]
+ *
+ * @package feehi\web
+ */
+class RedisSession extends Session
+{
+    /**
+     * @var \yii\redis\Connection|string|array the Redis [[Connection]] object or the application component ID of the Redis [[Connection]].
+     * This can also be an array that is used to create a redis [[Connection]] instance in case you do not want do configure
+     * redis connection as an application component.
+     * After the Session object is created, if you want to change this property, you should only assign it
+     * with a Redis [[Connection]] object.
+     */
+    public $redis;
+    public $keyPrefix;
+    public function init()
+    {
+        if (is_string($this->redis)) {
+            $this->redis = Yii::$app->get($this->redis);
+        } elseif (is_array($this->redis)) {
+            if (!isset($this->redis['class'])) {
+                $this->redis['class'] = Connection::className();
+            }
+            $this->redis = Yii::createObject($this->redis);
+        }
+        if (!$this->redis instanceof Connection) {
+            throw new InvalidConfigException("Session::redis must be either a Redis connection instance or the application component ID of a Redis connection.");
+        }
+        if ($this->keyPrefix === null) {
+            $this->keyPrefix = substr(md5(Yii::$app->id), 0, 5);
+        }
+        parent::init();
+    }
+    /**
+     * Returns a value indicating whether to use custom session storage.
+     * This method should be overridden to return true by child classes that implement custom session storage.
+     * To implement custom session storage, override these methods: [[openSession()]], [[closeSession()]],
+     * [[readSession()]], [[writeSession()]], [[destroySession()]] and [[gcSession()]].
+     * @return bool whether to use custom storage.
+     */
+    public function getUseCustomStorage()
+    {
+        return false;
+    }
+    /**
+     * swoole每隔设置的毫秒数执行此方法回收session
+     */
+    public function gcSession()
+    {
+        //redis自动回收资源
+    }
+    /**
+     * Session read handler.
+     * @internal Do not call this method directly.
+     * @param string $id session ID
+     * @return array the session data
+     */
+    public function readSession($id)
+    {
+        $data = $this->redis->executeCommand('GET', [$this->calculateKey($id)]);
+        $data= ($data === false || $data === null) ? [] :\yii\helpers\Json::decode($data);
+        return $data?$data:[];
+    }
+    /**
+     * Session write handler.
+     * @internal Do not call this method directly.
+     * @param string $id session ID
+     * @param string $data session data
+     * @return bool whether session write is successful
+     */
+    public function writeSession($id, $data)
+    {
+        // exception must be caught in session write handler
+        // http://us.php.net/manual/en/function.session-set-save-handler.php#refsect1-function.session-set-save-handler-notes
+        return (bool) $this->redis->executeCommand('SET', [$this->calculateKey($id), $data, 'EX', $this->getTimeout()]);
+    }
+    /**
+     * Session destroy handler.
+     * Do not call this method directly.
+     * @param string $id session ID
+     * @return bool whether session is destroyed successfully
+     */
+    public function destroySession($id)
+    {
+        $this->redis->executeCommand('DEL', [$this->calculateKey($id)]);
+        // @see https://github.com/yiisoft/yii2-redis/issues/82
+        $_SESSION = [];
+        return true;
+    }
+    /**
+     * Generates a unique key used for storing session data in cache.
+     * @param string $id session variable name
+     * @return string a safe cache key associated with the session variable name
+     */
+    protected function calculateKey($id)
+    {
+        return $this->keyPrefix . md5(json_encode([__CLASS__, $id]));
+    }
+}

--- a/src/web/Session.php
+++ b/src/web/Session.php
@@ -56,6 +56,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         if($this->timeout !== null) $this->_cookieParams['lifetime'] = $this->timeout;
     }
+
     /**
      * Returns a value indicating whether to use custom session storage.
      * This method should be overridden to return true by child classes that implement custom session storage.
@@ -67,10 +68,12 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
     {
         return false;
     }
+
     public function getSessionFullName()
     {
         return $this->getSavePath() . $this->_prefix . $this->getId();
     }
+
     public function persist()
     {
         $this->open();
@@ -85,6 +88,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         $_SESSION=$this->readSession($this->getId());
         $this->_started = true;
     }
+
     /**
      * Session read handler.
      * @internal Do not call this method directly.
@@ -141,13 +145,16 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             }
         }
     }
+
     public function getCookieParams()
     {
         return $this->_cookieParams;
     }
+
     public function setCookieParams(array $config){
         $this->_cookieParams = $config;
     }
+
     public function destroy()
     {
         $this->open();
@@ -155,11 +162,14 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             $_SESSION = [];
         }
     }
+
     public function getIsActive()
     {
         return $this->_started;
     }
+
     private $_hasSessionId;
+
     public function getHasSessionId()
     {
         if ($this->_hasSessionId === null) {
@@ -175,10 +185,12 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         return $this->_hasSessionId;
     }
+
     public function setHasSessionId($value)
     {
         $this->_hasSessionId = $value;
     }
+
     public function getId()
     {
         if( isset($_COOKIE[$this->getName()]) ){
@@ -188,16 +200,24 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         return $id;
     }
+
     public function regenerateID($deleteOldSession = false)
     {
     }
+
     public function getName()
     {
-        return $this->name?:'yzb_';
+        if($this->name==null){
+            $this->name='feehi_session';
+        }
+        return $this->name;
     }
-    public function setName($name){
-        return $this->name=$name;
+
+    public function setName($name)
+    {
+        $this->name=$name;
     }
+
     public function getSavePath()
     {
         if( substr( $this->savePath,-1) !='/' ){
@@ -205,35 +225,42 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         return $this->savePath;
     }
+
     public function setSavePath($value)
     {
         $this->savePath = $value;
     }
+
     public function getIterator()
     {
         $this->open();
         return new SessionIterator();
     }
+
     public function getCount()
     {
         $this->open();
         return count($_SESSION);
     }
+
     public function count()
     {
         $this->open();
         return $this->getCount();
     }
+
     public function get($key, $defaultValue = null)
     {
         $this->open();
         return isset($_SESSION[$key]) ? $_SESSION[$key] : $defaultValue;
     }
+
     public function set($key, $value)
     {
         $this->open();
         $_SESSION[$key] = $value;
     }
+
     public function remove($key)
     {
         $this->open();
@@ -244,6 +271,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         return null;
     }
+
     public function removeAll()
     {
         $this->open();
@@ -251,11 +279,13 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             unset($_SESSION[$key]);
         }
     }
+
     public function has($key)
     {
         $this->open();
         return isset($_SESSION[$key]);
     }
+
     protected function updateFlashCounters()
     {
         $this->open();
@@ -274,6 +304,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             unset($_SESSION[$this->flashParam]);
         }
     }
+
     public function getFlash($key, $defaultValue = null, $delete = true)
     {
         $this->open();
@@ -291,6 +322,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         return $defaultValue;
     }
+
     public function getAllFlashes($delete = false)
     {
         $this->open();
@@ -312,6 +344,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         $_SESSION[$this->flashParam] = $counters;
         return $flashes;
     }
+
     public function setFlash($key, $value = true, $removeAfterAccess = true)
     {
         $this->open();
@@ -320,6 +353,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         $_SESSION[$key] = $value;
         $_SESSION[$this->flashParam] = $counters;
     }
+
     public function addFlash($key, $value = true, $removeAfterAccess = true)
     {
         $this->open();
@@ -336,6 +370,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             }
         }
     }
+
     public function removeFlash($key)
     {
         $this->open();
@@ -345,6 +380,7 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         $_SESSION[$this->flashParam] = $counters;
         return $value;
     }
+
     public function removeAllFlashes()
     {
         $this->open();
@@ -354,31 +390,37 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
         }
         unset($_SESSION[$this->flashParam]);
     }
+
     public function hasFlash($key)
     {
         $this->open();
         return $this->getFlash($key) !== null;
     }
+
     public function offsetExists($offset)
     {
         $this->open();
         return isset($_SESSION[$offset]);
     }
+
     public function offsetGet($offset)
     {
         $this->open();
         return isset($_SESSION[$offset]) ? $_SESSION[$offset] : null;
     }
+
     public function offsetSet($offset, $item)
     {
         $this->open();
         $_SESSION[$offset] = $item;
     }
+
     public function offsetUnset($offset)
     {
         $this->open();
         unset($_SESSION[$offset]);
     }
+
     public function getTimeout()
     {
         if($this->timeout==null){

--- a/src/web/Session.php
+++ b/src/web/Session.php
@@ -22,6 +22,20 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 
     public $timeout = null;
 
+    /**
+     * 设置sessionName
+     * 配置文件中可设置sessionName，默认为 feehi_session
+     * 'components'=>[
+     * ...
+     * 'session'=>[
+     *      'name' => 'PHPSESSIONID',
+     * ]
+     * ...
+     * ]
+     * @var $name
+     */
+    public $name;
+
     private $_cookieParams = [
         'lifetime' => 1400,
         'path' => '/',
@@ -154,7 +168,15 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
 
     public function getName()
     {
-        return "feehi_session";
+        if($this->name==null){
+            $this->name='feehi_session';
+        }
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name=$name;
     }
 
     public function getSavePath()


### PR DESCRIPTION
更改初始化的session配置，使其可以支持重写session类，添加redis session类， 增加redis session的支持，主要是利用官方的redis类连接redis数据库，参考官方redis session的做法，使用 readSession 读取session，使用writeSession 写入session，所以调整了persist方法，persist调用 writeSession写入session。