### PR TITLE
收到请求时，清空 $_FILES 防止请求污染

### DIFF
--- a/src/swoole/SwooleServer.php
+++ b/src/swoole/SwooleServer.php
@@ -111,6 +111,8 @@ class SwooleServer
      */
     private function mountGlobalFilesVar($request)
     {
+        //清空已上传文件，防止跨请求污染
+        $_FILES = [];
         if (isset($request->files)) {
             $files = $request->files;
             foreach ($files as $k => $v) {


### PR DESCRIPTION
这里会导致一个BUG，上传文件后，后来的请求会自动携带 上一次上传的文件数据   :blush: