### PR TITLE
修复别名找不到

### DIFF
--- a/src/console/SwooleController.php
+++ b/src/console/SwooleController.php
@@ -106,6 +106,8 @@ class SwooleController extends \yii\console\Controller
             $aliases = [
                 '@web' => '',
                 '@webroot' => $web,
+                '@webroot/assets' => $web.'/assets',
+                '@web/assets' => $web.'/assets'
             ];
             $config['aliases'] = isset($config['aliases']) ? array_merge($aliases, $config['aliases']) : $aliases;
 


### PR DESCRIPTION
解决 `vendor/yiisoft/yii2/web/AssetManager.php:232` 产生的异常