### PR TITLE
修复Request对象getRawBody()为空的问题

### DIFF
--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -137,7 +137,7 @@ class Request extends \yii\web\Request
     public function getRawBody()
     {
         if ($this->_rawBody === null) {
-            $this->_rawBody = file_get_contents("php://input");
+            $this->_rawBody = $this->swooleRequest->rawContent();
             return $this->_rawBody;
         }
 


### PR DESCRIPTION
在swoole里 `file_get_contents("php://input")`是获取不到原始请求数据的，只能从`swoole_http_request`对象中获取。
大概的逻辑如下
```php
public function getRawBody()
{
    if ($this->_rawBody === null) {
        //$this->_rawBody = file_get_contents("php://input");
        $this->_rawBody = $this->swooleRequest->rawContent();
        return $this->_rawBody;
    }

    return $this->_rawBody;
}
```
这样就能保证在提交`json`数据的时候`Yii::$app->request->post()` 能正常获取到数据