### PR TITLE
修复@webroot别名问题

### DIFF
--- a/src/swoole/SwooleServer.php
+++ b/src/swoole/SwooleServer.php
@@ -143,6 +143,9 @@ class SwooleServer
             $_SERVER['HTTP_'.strtoupper($key)] = $value;
         }
         $_SERVER['SERVER_SOFTWARE'] = 'swoole/' . SWOOLE_VERSION;
+
+        // 修复DOCUMENT_ROOT真实路径
+        $_SERVER['DOCUMENT_ROOT'] = $this->webRoot;
     }
 
 }

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -326,7 +326,8 @@ class Request extends \yii\web\Request
             return $this->_scriptFile;
         }
 
-        return Yii::getAlias("@web");
+        // 模拟$_SERVER['SCRIPT_FILENAME']变量
+        return $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
     }
 
     public function setScriptFile($value)


### PR DESCRIPTION
之前提交的 #28 PR有点换汤不换药的意思，并没有从根本解决问题。

经过一番研究，发现`@web、@webroot`两个别名是在 `Application::bootstrap` 启动时设置的
```php
// vendor/yiisoft/yii2/web/Application.php:66
protected function bootstrap()
{
    $request = $this->getRequest();
    Yii::setAlias('@webroot', dirname($request->getScriptFile()));
    Yii::setAlias('@web', $request->getBaseUrl());

    parent::bootstrap();
}
```
由上面可得，`@webroot` 来自 `Request` 对象中的 `getScriptFile()` 方法。
而这个`Request`对象已经换成我们自己的了 `src/web/Request.php`，我们这个对象的 `getScriptFile()`方法如下：
```php
public function getScriptFile()
{
    if (isset($this->_scriptFile)) {
        return $this->_scriptFile;
    }

    return Yii::getAlias("@web");
}
```
直接通过 `Yii::getAlias("@web")`获取，这就产生了一个问题：
`Application`在实例化的时候会设置`@web、@webroot`两个别名，直接导致`@web`为空。
为空的原因是因为`Request::getBaseUrl()`方法，可以去看看这个方法的实现，具体就不再讨论了....
归根结底都是因为`Request::getScriptFile()`方法返回的值有问题。

解决思路：
1. 模拟出`$_SERVER['SCRIPT_FILENAME']`变量，同时将`Request::getScriptFile()`方法改为跟框架原来一致即可。
```php
// src/web/Request.php:323
public function getScriptFile()
{
    if (isset($this->_scriptFile)) {
        return $this->_scriptFile;
    }
    // 模拟$_SERVER['SCRIPT_FILENAME']变量
    return $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
}
```
2. 修复`$_SERVER['DOCUMENT_ROOT']`变量
```php
// src/swoole/SwooleServer.php:111
private function mountGlobalFilesVar($request)
{
    // some code...

    // 修复DOCUMENT_ROOT真实路径
    $_SERVER['DOCUMENT_ROOT'] = $this->webRoot;
}
```
3. 删除掉之前设置的别名
`src/console/SwooleController.php:106` 把相关的代码删除即可

